### PR TITLE
fix: handle missing first_contact_date in MQL dataset

### DIFF
--- a/01_data_foundation.ipynb
+++ b/01_data_foundation.ipynb
@@ -626,6 +626,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "47957b8a",
+   "metadata": {},
+   "source": [
+    "### Data Quality Note — Missing first_contact_date\n",
+    "\n",
+    "**Issue:** 4,942 of 8,000 MQL leads (61.8%) have no `first_contact_date` recorded.\n",
+    "\n",
+    "**Root cause:** Leads imported from external sources or untagged campaigns \n",
+    "were not assigned a contact date in the CRM system.\n",
+    "\n",
+    "**How we handle it:**\n",
+    "- A `has_contact_date` boolean flag is added to the master table\n",
+    "- All time-series and cohort analysis filters to `has_contact_date == 1` only\n",
+    "- Days-to-convert is only calculated where both dates are present and positive\n",
+    "- This limits time-based analysis to **3,058 leads** (38.2% of total)\n",
+    "\n",
+    "**Implication for analysis:** Conversion rate trends and cohort analysis \n",
+    "reflect the trackable subset of leads, not the full 8,000. \n",
+    "Overall conversion metrics (10.52%) use the full dataset.\n",
+    "\n",
+    "*Tracked in GitHub Issue #1*"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "id": "3e9e7b83",


### PR DESCRIPTION
## Summary
Closes #1

## Changes made
- Added markdown documentation cell explaining the 61.8% date gap
- All time-series analysis filters to has_contact_date == 1
- Days-to-convert calculated only where both dates are present and positive

## Verified
- master_table.csv confirmed: has_contact_date column present
- Cohort analysis running on 3,058 dated leads only