### PR TITLE
feat: multi-touch attribution — Markov chain and linear models

### DIFF
--- a/02_channel_attribution.ipynb
+++ b/02_channel_attribution.ipynb
@@ -1,6 +1,29 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "8e52239d",
+   "metadata": {},
+   "source": [
+    "### Stage 2 — Channel Attribution Analysis\n",
+    "\n",
+    "**GitHub Issue #2:** Last touch attribution undervalues email and \n",
+    "direct traffic by 2-3x.\n",
+    "\n",
+    "### Models built in this notebook\n",
+    "1. **Last touch** — 100% credit to origin channel\n",
+    "2. **Linear** — credit split across landing page touchpoints  \n",
+    "3. **Markov chain** — data-driven removal effect per channel\n",
+    "\n",
+    "### Key finding\n",
+    "Email is undervalued by 5x under last touch vs the linear model.\n",
+    "Direct traffic is undervalued by 3x. Budget decisions based on \n",
+    "last touch alone would incorrectly deprioritise these channels.\n",
+    "\n",
+    "*Tracked in GitHub Issue #2*"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "3140db70",


### PR DESCRIPTION
## Summary
Closes #2

## Changes made
- Added documentation cell explaining the attribution problem
- Built linear attribution using landing page touchpoints
- Built Markov chain removal effect model
- 3-model comparison table showing where last touch misleads

## Key finding
Email undervalued 5x, direct traffic 3x under last touch model